### PR TITLE
로그인 응답 데이터 변경

### DIFF
--- a/src/main/java/com/miracle/userservice/controller/UserController.java
+++ b/src/main/java/com/miracle/userservice/controller/UserController.java
@@ -4,9 +4,12 @@ import com.miracle.userservice.dto.request.UserJoinRequestDto;
 import com.miracle.userservice.dto.request.UserLoginRequestDto;
 import com.miracle.userservice.dto.response.CommonApiResponse;
 import com.miracle.userservice.dto.response.SuccessApiResponse;
+import com.miracle.userservice.dto.response.UserLoginResponseDto;
+import com.miracle.userservice.dto.response.UserLoginResponseDto.UserLoginResponseDtoBuilder;
+import com.miracle.userservice.entity.User;
 import com.miracle.userservice.service.UserService;
-import com.miracle.userservice.swagger.ApiUserLogin;
 import com.miracle.userservice.swagger.ApiUserJoin;
+import com.miracle.userservice.swagger.ApiUserLogin;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -14,6 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.validation.Valid;
+import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -26,26 +30,35 @@ public class UserController {
     @ApiUserLogin
     @ResponseStatus(HttpStatus.OK)
     @PostMapping("/login")
-    public CommonApiResponse login(@Valid @RequestBody UserLoginRequestDto dto, @RequestHeader String sessionId, HttpServletResponse response) {
-        log.debug("sessionId = {}, dto = {}", sessionId, dto);
+    public CommonApiResponse login(@Valid @RequestBody UserLoginRequestDto userLoginRequestDto, @RequestHeader String sessionId, HttpServletResponse response) {
+        log.debug("sessionId = {}, userLoginRequestDto = {}", sessionId, userLoginRequestDto);
 
-        boolean login = userService.login(dto);
-
-        String message;
+        Optional<User> userOpt = userService.login(userLoginRequestDto);
+        boolean success = userOpt.isPresent();
         int httpStatus;
-        Boolean data;
+        String message;
 
-        if (login) {
-            message = "로그인에 성공했습니다.";
+        UserLoginResponseDtoBuilder builder = UserLoginResponseDto.builder()
+                .success(success)
+                .id(null)
+                .email(null)
+                .name(null);
+        if (success) {
+            User user = userOpt.get();
             httpStatus = HttpStatus.OK.value();
-            data = Boolean.TRUE;
+            message = "로그인에 성공했습니다.";
+            builder
+                    .id(user.getId())
+                    .email(user.getEmail())
+                    .name(user.getName());
         } else {
-            message = "로그인에 실패했습니다.";
             httpStatus = HttpStatus.BAD_REQUEST.value();
-            data = Boolean.FALSE;
+            message = "로그인에 실패했습니다.";
         }
+
+        UserLoginResponseDto userLoginResponseDto = builder.build();
         response.setStatus(httpStatus);
-        return new SuccessApiResponse<>(httpStatus, message, data);
+        return new SuccessApiResponse<>(httpStatus, message, userLoginResponseDto);
     }
 
     @ApiUserJoin

--- a/src/main/java/com/miracle/userservice/dto/response/UserLoginResponseDto.java
+++ b/src/main/java/com/miracle/userservice/dto/response/UserLoginResponseDto.java
@@ -1,0 +1,29 @@
+package com.miracle.userservice.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public final class UserLoginResponseDto {
+
+    @Schema(description = "로그인 성공 여부")
+    private final boolean success;
+
+    @Schema(description = "유저 아이디")
+    private final Long id;
+
+    @Schema(description = "유저 이메일")
+    private final String email;
+
+    @Schema(description = "유저 이름")
+    private final String name;
+
+    @Builder
+    public UserLoginResponseDto(boolean success, Long id, String email, String name) {
+        this.success = success;
+        this.id = id;
+        this.email = email;
+        this.name = name;
+    }
+}

--- a/src/main/java/com/miracle/userservice/service/UserService.java
+++ b/src/main/java/com/miracle/userservice/service/UserService.java
@@ -1,8 +1,11 @@
 package com.miracle.userservice.service;
 
-import com.miracle.userservice.dto.request.UserLoginRequestDto;
 import com.miracle.userservice.dto.request.UserJoinRequestDto;
+import com.miracle.userservice.dto.request.UserLoginRequestDto;
+import com.miracle.userservice.entity.User;
 import com.miracle.userservice.exception.DuplicateEmailException;
+
+import java.util.Optional;
 
 public interface UserService {
 
@@ -11,10 +14,10 @@ public interface UserService {
      *
      * @param dto 로그인 정보(이메일, 비밀번호)
      * @throws NullPointerException {@code dto}가 null일 경우
-     * @author hazzokko
-     * @return DB에 로그인 정보 존재 시 true
+     * @author hazzokko, chocola
+     * @return 로그인에 성공했을 경우 해당 User 객체를 {@code Optional}로 감싸서 반환
      * */
-    boolean login(UserLoginRequestDto dto);
+    Optional<User> login(UserLoginRequestDto dto);
 
     /**
      * 회원 가입 요청을 처리하는 메서드

--- a/src/main/java/com/miracle/userservice/service/UserServiceImpl.java
+++ b/src/main/java/com/miracle/userservice/service/UserServiceImpl.java
@@ -20,13 +20,13 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
 
     @Override
-    public boolean login(UserLoginRequestDto dto) {
+    public Optional<User> login(UserLoginRequestDto dto) {
         String errorMessage = "UserLoginRequestDto is null";
         Objects.requireNonNull(dto, errorMessage);
 
-        Optional<User> user = userRepository.findByEmailAndPassword(dto.getEmail(), dto.getPassword().hashCode());
-
-        return user.isPresent();
+        String email = dto.getEmail();
+        int password = dto.getPassword().hashCode();
+        return userRepository.findByEmailAndPassword(email, password);
     }
 
     @Override

--- a/src/main/java/com/miracle/userservice/swagger/ApiUserLogin.java
+++ b/src/main/java/com/miracle/userservice/swagger/ApiUserLogin.java
@@ -23,39 +23,74 @@ import static java.lang.annotation.ElementType.METHOD;
         responses = {
                 @ApiResponse(
                         responseCode = SwaggerMsgUtil.ResponseCode.OK,
-                        description = "로그인 성공",
+                        description = "응답 성공",
                         content = @Content(
                                 mediaType = SwaggerMsgUtil.MediaType.APPLICATION_JSON,
-                                examples = @ExampleObject(
-                                        name = "성공",
-                                        value = """
-                                                {
-                                                    "httpStatus": 200,
-                                                    "message": "로그인에 성공했습니다.",
-                                                    "data": Boolean.TRUE
-                                                }
-                                                """
-                                ),
+                                examples = {
+                                        @ExampleObject(
+                                                name = "로그인 성공",
+                                                value = """
+                                                        {
+                                                          "httpStatus": 200,
+                                                          "message": "로그인에 성공했습니다.",
+                                                          "data": {
+                                                            "success": true,
+                                                            "id": 1,
+                                                            "email": "useremail@email.com",
+                                                            "name": "유저 이름"
+                                                          }
+                                                        }
+                                                        """
+                                        ),
+                                        @ExampleObject(
+                                                name = "로그인 실패",
+                                                value = """
+                                                        {
+                                                          "httpStatus": 200,
+                                                          "message": "로그인에 실패했습니다.",
+                                                          "data": {
+                                                            "success": false,
+                                                            "id": null,
+                                                            "email": null,
+                                                            "name": null
+                                                          }
+                                                        }
+                                                        """
+                                        )
+                                },
                                 schema = @Schema(implementation = SuccessApiResponse.class)
                         )
-
                 ),
                 @ApiResponse(
                         responseCode = SwaggerMsgUtil.ResponseCode.BAD_REQUEST,
                         description = "데이터 검증 실패",
                         content = @Content(
                                 mediaType = SwaggerMsgUtil.MediaType.APPLICATION_JSON,
-                                examples = @ExampleObject(
-                                                name = "실패",
+                                examples = {
+                                        @ExampleObject(
+                                                name = "이메일 검증 실패",
                                                 value = """
                                                         {
-                                                            "httpStatus": 400,
-                                                            "message": "계정 정보가 일치하지 않습니다.",
-                                                            "data": Boolean.FALSE
+                                                          "httpStatus": 400,
+                                                          "message": "이메일은 값이 입력되어야 합니다.",
+                                                          "code": "400_1",
+                                                          "exception": "MethodArgumentNotValidException"
                                                         }
                                                         """
-                                ),
-                                schema = @Schema(implementation = SuccessApiResponse.class)
+                                        ),
+                                        @ExampleObject(
+                                                name = "비밀번호 검증 실패",
+                                                value = """
+                                                        {
+                                                          "httpStatus": 400,
+                                                          "message": "비밀번호는 값이 입력되어야 합니다.",
+                                                          "code": "400_2",
+                                                          "exception": "MethodArgumentNotValidException"
+                                                        }
+                                                        """
+                                        )
+                                },
+                                schema = @Schema(implementation = ErrorApiResponse.class)
                         )
                 ),
                 @ApiResponse(


### PR DESCRIPTION
Gateway Service에서 로그인 응답 데이터를 변경해달라는 요청이 들어와서 수정함

1. 응답 데이터에 유저의 id, email, name을 포함시킴
2. 그에 따라 API 명세서를 수정함